### PR TITLE
Update release date for version 0.0.10 in changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [0.0.10] - Unreleased
+## [0.0.10] - 24/11/2025
 
 ### Fixed
 - **JUnit Platform Launcher missing in Gradle 9.2.0** - Fixed test execution failure in OAuth module


### PR DESCRIPTION
Changed the status of version 0.0.10 from 'Unreleased' to '24/11/2025' in CHANGELOG.md to reflect the release date.

[code_of_conduct]: https://github.com/YusufsDiscordbot/MystiGuardian/blob/main/.github/CODE_OF_CONDUCT.md

[new_issue]: https://github.com/RealYusufIsmail/Armour-and-Tools-Mod/issues/new/choose

## Pull Request Etiquette

<!--
  There are several guidelines you should follow in order for your
  Pull Request to be merged.
-->

- [x] I have checked the PRs for upcoming features/bug fixes.
- [x] I have read the [code of conduct][code_of_conduct].

<!--
  It is sometimes better to include more changes in a single commit. 
  If you find yourself having an overwhelming amount of commits, you
  can **rebase** your branch.
-->

<!-- Replace "NaN" with an issue number if this is a response to an issue -->

Closes : NaN

## Description

This pull request updates the project changelog to finalize the release date and document a bug fix for the OAuth module.

Release documentation:

* [`CHANGELOG.md`](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edL8-R8): Updated the release date for version 0.0.10 to "24/11/2025" and moved it out of the "Unreleased" section.

Bug fix documentation:

* [`CHANGELOG.md`](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edL8-R8): Added a note that the JUnit Platform Launcher issue causing test execution failures in the OAuth module has been fixed.